### PR TITLE
Fix score prediction key typo

### DIFF
--- a/src/Components/Fixtures/Fixture-Components/ScorePredictionResults.js
+++ b/src/Components/Fixtures/Fixture-Components/ScorePredictionResults.js
@@ -33,7 +33,7 @@ export default function ScorePredictionResults({
   const barchartDataAwayGoals = getBarchartData(matchPredictions?.awayGoals);
   const barchartDataHomeGoals = getBarchartData(matchPredictions?.homeGoals);
   // const barchartDataScoreline = getBarchartData(
-  //   matchPredictions?.scorePrecitions
+  //   matchPredictions?.scorePredictions
   // );
 
   // Check if match predictions are loaded
@@ -41,15 +41,15 @@ export default function ScorePredictionResults({
     return <div>Loading...</div>; // Or a spinner/loading component
   }
   let highestScorePredictions;
-  if (matchPredictions?.scorePrecitions) {
+  if (matchPredictions?.scorePredictions) {
     const maxValue = Math.max(
-      ...Object.values(matchPredictions?.scorePrecitions)
+      ...Object.values(matchPredictions?.scorePredictions)
     );
 
     // Filter keys that have the maximum value
     highestScorePredictions = Object.keys(
-      matchPredictions?.scorePrecitions
-    ).filter((key) => matchPredictions?.scorePrecitions[key] === maxValue);
+      matchPredictions?.scorePredictions
+    ).filter((key) => matchPredictions?.scorePredictions[key] === maxValue);
   }
   const style = {
     position: "absolute",
@@ -108,7 +108,7 @@ export default function ScorePredictionResults({
                 Predicted Scoreline
               </h1>
               <Piechart
-                chartData={matchPredictions?.scorePrecitions || []}
+                chartData={matchPredictions?.scorePredictions || []}
                 width={isMobile ? 300 : 220}
                 height={220}
                 outerRadius={75}

--- a/src/Firebase/Firebase.js
+++ b/src/Firebase/Firebase.js
@@ -306,7 +306,7 @@ export const handlePredictTeamScore = async (data) => {
     path: `groups/${data.groupId}/seasons/2024/predictions`,
     docId: data.matchId,
     data: {
-      scorePrecitions: { [data.score]: increment(1) },
+      scorePredictions: { [data.score]: increment(1) },
       homeGoals: { [data.homeGoals]: increment(1) },
       awayGoals: { [data.awayGoals]: increment(1) },
     },


### PR DESCRIPTION
## Summary
- fix `scorePrecitions` typos in Firebase update logic
- adjust score prediction selector references and chart props

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ba88b6848325b3566e0ec1c6a773