### PR TITLE
Remove unused counter example

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,25 +1,3 @@
-// import React from "react";
-// import { useSelector, useDispatch } from "react-redux";
-// import { increment, decrement, incrementByAmount } from "./redux/counterSlice";
-
-// function App() {
-//   const count = useSelector((state) => state.counter.value);
-//   const dispatch = useDispatch();
-
-//   return (
-//     <div style={{ textAlign: "center", marginTop: "50px" }}>
-//       <h1>Redux Counter</h1>
-//       <h2>{count}</h2>
-//       <button onClick={() => dispatch(increment())}>Increment</button>
-//       <button onClick={() => dispatch(decrement())}>Decrement</button>
-//       <button onClick={() => dispatch(incrementByAmount(5))}>
-//         Increment by 5
-//       </button>
-//     </div>
-//   );
-// }
-
-// export default App;
 import React, { useEffect } from "react";
 
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";


### PR DESCRIPTION
## Summary
- drop the old commented counter example from `App.js`

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841cfca60fc8325b0a45f1e77317edc